### PR TITLE
❗️[develop ← feature/waypoint-api-exception] 예외 처리 및 유효성 검사

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/application/waypoint/WaypointService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/waypoint/WaypointService.java
@@ -4,6 +4,8 @@ import com.kakaotechcampus.journey_planner.domain.plan.Plan;
 import com.kakaotechcampus.journey_planner.domain.plan.PlanRepository;
 import com.kakaotechcampus.journey_planner.domain.waypoint.Waypoint;
 import com.kakaotechcampus.journey_planner.domain.waypoint.WaypointRepository;
+import com.kakaotechcampus.journey_planner.global.exception.CustomRuntimeException;
+import com.kakaotechcampus.journey_planner.global.exception.ErrorCode;
 import com.kakaotechcampus.journey_planner.presentation.dto.waypoint.WaypointRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +27,7 @@ public class WaypointService {
     @Transactional
     public void addWaypoint(Long planId, Waypoint waypoint) {
         Plan plan = planRepository.findById(planId)
-                .orElseThrow(() -> new IllegalArgumentException("Plan not found: " + planId));
+                .orElseThrow(() -> new CustomRuntimeException(ErrorCode.PLAN_NOT_FOUND));
 
         // 단방향: Waypoint 쪽에 Plan을 세팅
         waypoint.assignToPlan(plan);
@@ -35,8 +37,7 @@ public class WaypointService {
     @Transactional
     public void updateWaypoint(Long planId, Long waypointId, WaypointRequest request) {
         Waypoint waypoint = waypointRepository.findByIdAndPlanId(waypointId, planId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Waypoint not found: " + waypointId + " in plan " + planId));
+                .orElseThrow(() -> new CustomRuntimeException(ErrorCode.WAYPOINT_NOT_FOUND));
 
         waypoint.update(
                 request.name(),
@@ -54,8 +55,7 @@ public class WaypointService {
     @Transactional
     public void removeWaypoint(Long planId, Long waypointId) {
         Waypoint waypoint = waypointRepository.findByIdAndPlanId(waypointId, planId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Waypoint not found: " + waypointId + " in plan " + planId));
+                .orElseThrow(() -> new CustomRuntimeException(ErrorCode.WAYPOINT_NOT_FOUND));
 
         waypointRepository.delete(waypoint);
     }

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 서버 → 클라이언트 메시지 브로커 prefix
-        registry.enableSimpleBroker("/topic");
+        registry.enableSimpleBroker("/topic", "/queue");
 
         // 클라이언트 → 서버로 보낼 때 prefix
         registry.setApplicationDestinationPrefixes("/app");

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
@@ -7,11 +7,21 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
+    // PDF
     NO_FILE(HttpStatus.NOT_FOUND, "NO_FILE","파일 경로를 찾을 수 없습니다."),
+
+    // Plan
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_NOT_FOUND", "해당 계획을 찾을 수 없습니다."),
+
+    // Waypoint
+    WAYPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, "WAYPOINT_NOT_FOUND", "해당 웨이포인트를 찾을 수 없습니다."),
+
+    // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 멤버를 찾을 수 없습니다."),
-    LOGIN_FAILED(HttpStatus.BAD_REQUEST, "LOGIN_FAILED", "로그인에 실패하였습니다."),
     ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "ALREADY_REGISTERED", "이미 존재하는 멤버입니다."),
+
+    // Auth
+    LOGIN_FAILED(HttpStatus.BAD_REQUEST, "LOGIN_FAILED", "로그인에 실패하였습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "잘못된 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN_EXPIRED", "만료된 토큰입니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력 형식이 잘못되었습니다.");

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/WebSocketErrorResponse.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/WebSocketErrorResponse.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.journey_planner.global.exception;
+
+public record WebSocketErrorResponse(
+        String code,
+        String message
+) { }

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/WebSocketExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.kakaotechcampus.journey_planner.global.exception;
+
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@ControllerAdvice
+public class WebSocketExceptionHandler {
+
+    @MessageExceptionHandler(CustomRuntimeException.class)
+    @SendToUser(destinations = "/queue/errors", broadcast = false)
+    public WebSocketErrorResponse handleCustomRuntimeException(CustomRuntimeException e) {
+        return new WebSocketErrorResponse(e.getCode(), e.getMessage());
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/WebSocketExceptionHandler.java
@@ -1,16 +1,33 @@
 package com.kakaotechcampus.journey_planner.global.exception;
 
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import java.util.Objects;
 
 @ControllerAdvice
 public class WebSocketExceptionHandler {
 
-    @MessageExceptionHandler(CustomRuntimeException.class)
+    @MessageExceptionHandler({CustomRuntimeException.class})
     @SendToUser(destinations = "/queue/errors", broadcast = false)
     public WebSocketErrorResponse handleCustomRuntimeException(CustomRuntimeException e) {
+
         return new WebSocketErrorResponse(e.getCode(), e.getMessage());
     }
 
+    @MessageExceptionHandler(MethodArgumentNotValidException.class)
+    @SendToUser(destinations = "/queue/errors", broadcast = false)
+    public WebSocketErrorResponse handleValidationException(MethodArgumentNotValidException e) {
+
+        String errorMessage = Objects.requireNonNull(e.getBindingResult().getAllErrors())
+                .stream()
+                .findFirst()
+                .map(ObjectError::getDefaultMessage)
+                .orElse("유효성 검사 실패");
+
+        return new WebSocketErrorResponse("VALIDATION_ERROR", errorMessage);
+    }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/waypoint/WaypointRequest.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/waypoint/WaypointRequest.java
@@ -1,20 +1,34 @@
 package com.kakaotechcampus.journey_planner.presentation.dto.waypoint;
 
 import com.kakaotechcampus.journey_planner.domain.waypoint.LocationCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
 
 public record WaypointRequest(
+        @NotBlank(message = "웨이포인트명은 필수 입력값입니다.")
+        @Size(max = 20, message = "웨이포인트명은 최대 20자까지 허용됩니다.")
         String name,
+
         String description,
 
+        @NotBlank(message = "주소는 필수 입력값입니다.")
         String address,
 
+        @NotNull(message = "시작 시각은 필수 입력값입니다.")
         LocalDateTime startTime,
+
+        @NotNull(message = "종료 시각은 필수 입력값입니다.")
         LocalDateTime endTime,
 
+        @NotNull(message = "위치 카테고리는 필수 입력값입니다.")
         LocationCategory locationCategory,
 
+        @NotNull(message = "x좌표는 필수 입력값입니다.")
         Float xPosition,
+
+        @NotNull(message = "y좌표는 필수 입력값입니다.")
         Float yPosition
 ) {}

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/waypoint/WaypointController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/waypoint/WaypointController.java
@@ -4,12 +4,12 @@ import com.kakaotechcampus.journey_planner.application.waypoint.WaypointService;
 import com.kakaotechcampus.journey_planner.domain.waypoint.Waypoint;
 import com.kakaotechcampus.journey_planner.domain.waypoint.WaypointMapper;
 import com.kakaotechcampus.journey_planner.presentation.dto.waypoint.WaypointRequest;
+import jakarta.validation.Valid;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.Map;
@@ -34,7 +34,7 @@ public class WaypointController {
 
     // 새 waypoint 생성 후 전체 리스트 전송
     @MessageMapping("/create")
-    public void createWaypoint(@DestinationVariable Long planId, @Validated @Payload WaypointRequest request) {
+    public void createWaypoint(@DestinationVariable Long planId, @Valid @Payload WaypointRequest request) {
         Waypoint waypoint = WaypointMapper.toEntity(request);
         waypointService.addWaypoint(planId, waypoint);
 
@@ -46,7 +46,7 @@ public class WaypointController {
     public void updateWaypoint(
             @DestinationVariable Long planId,
             @DestinationVariable Long waypointId,
-            WaypointRequest request) {
+            @Valid WaypointRequest request) {
 
         waypointService.updateWaypoint(planId, waypointId, request);
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/waypoint/WaypointController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/waypoint/WaypointController.java
@@ -6,8 +6,10 @@ import com.kakaotechcampus.journey_planner.domain.waypoint.WaypointMapper;
 import com.kakaotechcampus.journey_planner.presentation.dto.waypoint.WaypointRequest;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.Map;
@@ -32,7 +34,7 @@ public class WaypointController {
 
     // 새 waypoint 생성 후 전체 리스트 전송
     @MessageMapping("/create")
-    public void createWaypoint(@DestinationVariable Long planId, WaypointRequest request) {
+    public void createWaypoint(@DestinationVariable Long planId, @Validated @Payload WaypointRequest request) {
         Waypoint waypoint = WaypointMapper.toEntity(request);
         waypointService.addWaypoint(planId, waypoint);
 

--- a/src/main/resources/static/websocket-test.html
+++ b/src/main/resources/static/websocket-test.html
@@ -116,10 +116,8 @@
         return Number.isNaN(n) ? null : n;
     }
 
-    // 서버에서 온 ISO-like 문자열을 datetime-local 값으로 맞춤 (초/밀리초 제거)
     function toLocalDatetimeInput(v) {
         if (!v) return "";
-        // 예상: "2025-09-06T12:34" 또는 "2025-09-06T12:34:56"
         return v.toString().slice(0, 16);
     }
 
@@ -140,6 +138,17 @@
             client.subscribe(`/topic/plans/${planId}`, (msg) => {
                 log("📩 Received: " + msg.body, "info");
                 renderWaypoints(msg.body);
+            });
+
+            // ✅ 에러 메시지 구독 (서버에서 /user/queue/errors 로 보낸 경우)
+            client.subscribe(`/user/queue/errors`, (msg) => {
+                log("❌ Error: " + msg.body, "error");
+                try {
+                    const error = JSON.parse(msg.body);
+                    alert(`에러 발생!\n[${error.code}] ${error.message}`);
+                } catch (e) {
+                    alert("에러 발생!\n" + msg.body);
+                }
             });
 
             // 접속 후 전체 동기화
@@ -176,13 +185,13 @@
             address: document.getElementById("wpAddress").value,
             startTime: document.getElementById("wpStartTime").value || null,
             endTime: document.getElementById("wpEndTime").value || null,
-            locationCategory: document.getElementById("wpCategory").value || null, // ENUM 이름
+            locationCategory: document.getElementById("wpCategory").value || null,
             xPosition: parseFloat(document.getElementById("wpX").value),
             yPosition: parseFloat(document.getElementById("wpY").value)
         };
 
         client.publish({
-            destination: `/app/plans/${planId}/waypoints/create`, // dotted 스타일
+            destination: `/app/plans/${planId}/waypoints/create`,
             body: JSON.stringify(waypoint),
             headers: { "content-type": "application/json" },
         });
@@ -192,7 +201,7 @@
     function deleteWaypointById(waypointId) {
         const planId = document.getElementById("planId").value;
         client.publish({
-            destination: `/app/plans/${planId}/waypoints/${waypointId}/delete`, // dotted 스타일
+            destination: `/app/plans/${planId}/waypoints/${waypointId}/delete`,
         });
         log(`➡️ Sent delete request for waypointId=${waypointId}`, "send");
     }
@@ -211,7 +220,7 @@
 
         const planId = document.getElementById("planId").value;
         client.publish({
-            destination: `/app/plans/${planId}/waypoints/${waypointId}/update`, // dotted 스타일
+            destination: `/app/plans/${planId}/waypoints/${waypointId}/update`,
             body: JSON.stringify(updatedWaypoint),
             headers: { "content-type": "application/json" },
         });
@@ -231,7 +240,6 @@
             return;
         }
 
-        // 기대 포맷: { type: "FULL_UPDATE", waypoints: WaypointResponse[] }
         if (!payload || payload.type !== "FULL_UPDATE" || !Array.isArray(payload.waypoints)) {
             return;
         }


### PR DESCRIPTION
# [develop ← feature/waypoint-api-exception] 예외 처리 및 유효성 검사

## 관련된 ISSUE
- closed: #8 

## 요약
- [x] 기능 추가 : 예외 처리 및 유효성 검사 로직을 추가했습니다.
`GlobalExceptionHandler`에 넣게 되면 혼동의 여지가 있을 것 같아서 따로 `WebSocketExceptionHandler` 파일을 만들었습니다.
- [x] 리팩토링 : websocket-test.html에 에러 발생 시 alert 하는 코드를 추가했습니다.

## 얻어낸 효과 ( OPTIONAL )
    2단계 동안 배웠던 HTTP 예외처리와는 메시지를 전송하는 방식에 약간 차이가 있었는데, 공식 문서를 참고하여 이를 해결할 수 있었습니다.

## 궁금한 점
- 웨이포인트명이나 설명 같은 텍스트에 관해서 글자수 제한을 어느 정도로 하는 것이 좋을까요?

## Reference
### Spring STOMP 공식문서
- [예외처리 핸들러](https://docs.spring.io/spring-framework/reference/web/websocket/stomp/handle-annotations.html#websocket-stomp-exception-handler)
- [특정 유저에게만 메시지 전송](https://docs.spring.io/spring-framework/reference/web/websocket/stomp/user-destination.html)