### PR TITLE
[develop ← feature/memo-api] Memo api 생성

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/application/memo/MemoService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/memo/MemoService.java
@@ -1,0 +1,59 @@
+package com.kakaotechcampus.journey_planner.application.memo;
+
+import com.kakaotechcampus.journey_planner.domain.memo.Memo;
+import com.kakaotechcampus.journey_planner.domain.memo.MemoRepository;
+import com.kakaotechcampus.journey_planner.domain.plan.Plan;
+import com.kakaotechcampus.journey_planner.domain.plan.PlanRepository;
+import com.kakaotechcampus.journey_planner.global.exception.CustomRuntimeException;
+import com.kakaotechcampus.journey_planner.global.exception.ErrorCode;
+import com.kakaotechcampus.journey_planner.presentation.dto.memo.MemoRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+
+    private final PlanRepository planRepository;
+    private final MemoRepository memoRepository;
+
+    @Transactional
+    public void addMemo(Long planId, Memo memo) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new CustomRuntimeException(ErrorCode.PLAN_NOT_FOUND));
+
+        memo.assignToPlan(plan);
+        memoRepository.save(memo);
+    }
+
+    @Transactional
+    public void updateMemo(Long planId, Long memoId, MemoRequest request) {
+         Memo memo = memoRepository.findByIdAndPlanId(memoId, planId)
+                 .orElseThrow(() -> new CustomRuntimeException(ErrorCode.MEMO_NOT_FOUND));
+
+         memo.update(
+             request.title(),
+             request.content(),
+             request.xPosition(),
+             request.yPosition()
+         );
+
+    }
+
+    @Transactional
+    public void removeMemo(Long planId, Long memoId) {
+        Memo memo = memoRepository.findByIdAndPlanId(memoId, planId)
+                .orElseThrow(() -> new CustomRuntimeException(ErrorCode.MEMO_NOT_FOUND));
+
+        memoRepository.delete(memo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Memo> getMemos(Long planId) {
+        return memoRepository.findByPlanId(planId);
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/Memo.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/Memo.java
@@ -20,7 +20,7 @@ public class Memo {
     private Float yPosition;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "plan_id")
+    @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
     protected Memo() {}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/Memo.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/Memo.java
@@ -1,0 +1,43 @@
+package com.kakaotechcampus.journey_planner.domain.memo;
+
+import com.kakaotechcampus.journey_planner.domain.plan.Plan;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Memo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private Float xPosition;
+    private Float yPosition;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    protected Memo() {}
+
+    public Memo(String title, String content, float xPosition, float yPosition) {
+        this.title = title;
+        this.content = content;
+        this.xPosition = xPosition;
+        this.yPosition = yPosition;
+    }
+
+    public void assignToPlan(Plan plan) {this.plan = plan;}
+
+    public void update(String title, String content, float xPosition, float yPosition) {
+        this.title = title;
+        this.content = content;
+        this.xPosition = xPosition;
+        this.yPosition = yPosition;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/MemoMapper.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/MemoMapper.java
@@ -1,0 +1,35 @@
+package com.kakaotechcampus.journey_planner.domain.memo;
+
+import com.kakaotechcampus.journey_planner.presentation.dto.memo.MemoRequest;
+import com.kakaotechcampus.journey_planner.presentation.dto.memo.MemoResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MemoMapper {
+
+    public static Memo toEntity(MemoRequest request) {
+        return new Memo(
+                request.title(),
+                request.content(),
+                request.xPosition(),
+                request.yPosition()
+        );
+    }
+
+    public static MemoResponse toResponse(Memo memo) {
+        return new MemoResponse(
+                memo.getId(),
+                memo.getTitle(),
+                memo.getContent(),
+                memo.getXPosition(),
+                memo.getYPosition()
+        );
+    }
+
+    public static List<MemoResponse> toResponseList(List<Memo> memos) {
+        return memos.stream()
+                .map(MemoMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/MemoRepository.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memo/MemoRepository.java
@@ -1,0 +1,12 @@
+package com.kakaotechcampus.journey_planner.domain.memo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+    Optional<Memo> findByIdAndPlanId(Long memoId, Long planId);
+
+    List<Memo> findByPlanId(Long planId);
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/waypoint/Waypoint.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/waypoint/Waypoint.java
@@ -15,7 +15,7 @@ public class Waypoint {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "plan_id")
+    @JoinColumn(name = "plan_id",  nullable = false)
     private Plan plan;
 
     private String name;

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     // Waypoint
     WAYPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, "WAYPOINT_NOT_FOUND", "해당 웨이포인트를 찾을 수 없습니다."),
 
+    // Memo
+    MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMO_NOT_FOUND", "해당 메모를 찾을 수 없습니다."),
+
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 멤버를 찾을 수 없습니다."),
     ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "ALREADY_REGISTERED", "이미 존재하는 멤버입니다."),

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/memo/MemoRequest.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/memo/MemoRequest.java
@@ -1,8 +1,19 @@
 package com.kakaotechcampus.journey_planner.presentation.dto.memo;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record MemoRequest(
+
+    @NotBlank(message = "제목은 필수 입력값입니다.")
     String title,
+
+    @NotBlank(message = "내용은 필수 입력값입니다.")
     String content,
+
+    @NotNull(message = "x좌표는 필수 입력값입니다.")
     Float xPosition,
+
+    @NotNull(message = "y좌표는 필수 입력값입니다.")
     Float yPosition
 ) {}

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/memo/MemoRequest.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/memo/MemoRequest.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.journey_planner.presentation.dto.memo;
+
+public record MemoRequest(
+    String title,
+    String content,
+    Float xPosition,
+    Float yPosition
+) {}

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/memo/MemoResponse.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/dto/memo/MemoResponse.java
@@ -1,0 +1,9 @@
+package com.kakaotechcampus.journey_planner.presentation.dto.memo;
+
+public record MemoResponse(
+        Long id,
+        String title,
+        String content,
+        Float xPosition,
+        Float yPosition
+) {}

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/memo/MemoController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/memo/MemoController.java
@@ -1,0 +1,73 @@
+package com.kakaotechcampus.journey_planner.presentation.memo;
+
+import com.kakaotechcampus.journey_planner.application.memo.MemoService;
+import com.kakaotechcampus.journey_planner.domain.memo.Memo;
+import com.kakaotechcampus.journey_planner.domain.memo.MemoMapper;
+import com.kakaotechcampus.journey_planner.presentation.dto.memo.MemoRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@MessageMapping("/plans/{planId}/memos")
+@RequiredArgsConstructor
+public class MemoController {
+
+    private final MemoService memoService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    //클라이언트가 구독 후 초기 상태 요청 시 전체 memo 전송
+    @MessageMapping("/init")
+    public void initMemos(@DestinationVariable Long planId) {
+        sendFullMemos(planId);
+    }
+
+    // 새 memo 생성 후 전체 리스트 전송
+    @MessageMapping("/create")
+    public void createMemo(@DestinationVariable Long planId, MemoRequest request) {
+        Memo memo = MemoMapper.toEntity(request);
+        memoService.addMemo(planId, memo);
+
+        sendFullMemos(planId);
+    }
+
+    // memo 수정 후 전체 리스트 전송
+    @MessageMapping("/{memoId}/update")
+    public void updateMemo(
+            @DestinationVariable Long planId,
+            @DestinationVariable Long memoId,
+            MemoRequest request) {
+
+        memoService.updateMemo(planId, memoId, request);
+
+        sendFullMemos(planId);
+    }
+
+    // memo 삭제 후 전체 리스트 전송
+    @MessageMapping("/{memoId}/delete")
+    public void deleteMemo(
+            @DestinationVariable Long planId,
+            @DestinationVariable Long memoId
+    ) {
+        memoService.removeMemo(planId, memoId);
+
+        sendFullMemos(planId);
+    }
+
+    // plan의 전체 memo 리스트를 전송 (Broadcast)
+    private void sendFullMemos(Long planId) {
+        List<Memo> memos = memoService.getMemos(planId);
+        messagingTemplate.convertAndSend(
+                "/topic/plans/" + planId,
+                Map.of(
+                        "type", "FULL_UPDATE",
+                        "memos", MemoMapper.toResponseList(memos)
+                )
+        );
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/memo/MemoController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/memo/MemoController.java
@@ -4,9 +4,11 @@ import com.kakaotechcampus.journey_planner.application.memo.MemoService;
 import com.kakaotechcampus.journey_planner.domain.memo.Memo;
 import com.kakaotechcampus.journey_planner.domain.memo.MemoMapper;
 import com.kakaotechcampus.journey_planner.presentation.dto.memo.MemoRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
@@ -29,7 +31,7 @@ public class MemoController {
 
     // 새 memo 생성 후 전체 리스트 전송
     @MessageMapping("/create")
-    public void createMemo(@DestinationVariable Long planId, MemoRequest request) {
+    public void createMemo(@DestinationVariable Long planId, @Valid @Payload MemoRequest request) {
         Memo memo = MemoMapper.toEntity(request);
         memoService.addMemo(planId, memo);
 
@@ -41,7 +43,7 @@ public class MemoController {
     public void updateMemo(
             @DestinationVariable Long planId,
             @DestinationVariable Long memoId,
-            MemoRequest request) {
+            @Valid @Payload MemoRequest request) {
 
         memoService.updateMemo(planId, memoId, request);
 

--- a/src/main/resources/static/websocket-test.html
+++ b/src/main/resources/static/websocket-test.html
@@ -2,13 +2,13 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <title>Waypoint WebSocket Test</title>
+    <title>Waypoint & Memo WebSocket Test</title>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100 min-h-screen flex flex-col items-center p-6">
-<h1 class="text-2xl font-bold mb-4">📍 Waypoint WebSocket Test</h1>
+<h1 class="text-2xl font-bold mb-4">📍 Waypoint & 📝 Memo WebSocket Test</h1>
 
 <div class="flex w-full max-w-6xl gap-4">
     <div class="flex-1 flex flex-col gap-4 min-w-0">
@@ -19,22 +19,18 @@
                 <button onclick="connect()" class="px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600">Connect</button>
                 <button onclick="disconnect()" class="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600">Disconnect</button>
             </div>
-
             <div class="flex gap-2 mb-4">
-                <button onclick="initWaypoints()" class="flex-1 px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Refresh (init)</button>
+                <button onclick="initData()" class="flex-1 px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Refresh (init)</button>
                 <button onclick="createWaypoint()" class="flex-1 px-3 py-2 bg-indigo-500 text-white rounded hover:bg-indigo-600">Create Waypoint</button>
+                <button onclick="createMemo()" class="flex-1 px-3 py-2 bg-purple-500 text-white rounded hover:bg-purple-600">Create Memo</button>
             </div>
         </div>
 
         <div class="bg-white shadow rounded-lg p-4">
             <h2 class="font-semibold mb-2">새 Waypoint 입력</h2>
             <div class="grid grid-cols-2 gap-3">
-                <label class="flex flex-col">
-                    이름
-                    <input type="text" id="wpName" class="border rounded p-2" />
-                </label>
-                <label class="flex flex-col">
-                    카테고리
+                <label class="flex flex-col">이름<input type="text" id="wpName" class="border rounded p-2" /></label>
+                <label class="flex flex-col">카테고리
                     <select id="wpCategory" class="border rounded p-2">
                         <option value="" selected disabled>카테고리 선택</option>
                         <option value="DEFAULT">DEFAULT</option>
@@ -45,48 +41,35 @@
                         <option value="TRANSPORTATION">TRANSPORTATION</option>
                     </select>
                 </label>
+                <label class="flex flex-col col-span-2">설명<input type="text" id="wpDescription" class="border rounded p-2" /></label>
+                <label class="flex flex-col col-span-2">주소<input type="text" id="wpAddress" class="border rounded p-2" /></label>
+                <label class="flex flex-col">시작 시간<input type="datetime-local" id="wpStartTime" class="border rounded p-2" /></label>
+                <label class="flex flex-col">종료 시간<input type="datetime-local" id="wpEndTime" class="border rounded p-2" /></label>
+                <label class="flex flex-col">X 좌표 (float)<input type="number" id="wpX" step="0.01" class="border rounded p-2" /></label>
+                <label class="flex flex-col">Y 좌표 (float)<input type="number" id="wpY" step="0.01" class="border rounded p-2" /></label>
+            </div>
+        </div>
 
-                <label class="flex flex-col col-span-2">
-                    설명
-                    <input type="text" id="wpDescription" class="border rounded p-2" />
-                </label>
-
-                <label class="flex flex-col col-span-2">
-                    주소
-                    <input type="text" id="wpAddress" class="border rounded p-2" />
-                </label>
-
-                <label class="flex flex-col">
-                    시작 시간
-                    <input type="datetime-local" id="wpStartTime" class="border rounded p-2" />
-                </label>
-                <label class="flex flex-col">
-                    종료 시간
-                    <input type="datetime-local" id="wpEndTime" class="border rounded p-2" />
-                </label>
-
-                <label class="flex flex-col">
-                    X 좌표 (float)
-                    <input type="number" id="wpX" step="0.01" class="border rounded p-2" />
-                </label>
-                <label class="flex flex-col">
-                    Y 좌표 (float)
-                    <input type="number" id="wpY" step="0.01" class="border rounded p-2" />
-                </label>
+        <div class="bg-white shadow rounded-lg p-4">
+            <h2 class="font-semibold mb-2">새 Memo 입력</h2>
+            <div class="grid grid-cols-2 gap-3">
+                <label class="flex flex-col col-span-2">제목<input type="text" id="memoTitle" class="border rounded p-2" /></label>
+                <label class="flex flex-col col-span-2">내용<input type="text" id="memoContent" class="border rounded p-2" /></label>
+                <label class="flex flex-col">X 좌표 (float)<input type="number" id="memoX" step="0.01" class="border rounded p-2" /></label>
+                <label class="flex flex-col">Y 좌표 (float)<input type="number" id="memoY" step="0.01" class="border rounded p-2" /></label>
             </div>
         </div>
 
         <div class="bg-white shadow rounded-lg p-4 flex-1 min-w-0">
             <h2 class="font-semibold mb-2">로그</h2>
-            <div id="log"
-                 class="border rounded p-2 h-64 overflow-auto bg-gray-50 text-sm font-mono break-all whitespace-pre-wrap"></div>
+            <div id="log" class="border rounded p-2 h-64 overflow-auto bg-gray-50 text-sm font-mono break-all whitespace-pre-wrap"></div>
         </div>
     </div>
 
     <div class="flex-1">
         <div class="bg-white shadow rounded-lg p-4 h-full flex flex-col">
-            <h2 class="font-semibold mb-2">Waypoint 목록</h2>
-            <div id="waypointList" class="border rounded p-2 overflow-auto flex-1 bg-gray-50"></div>
+            <h2 class="font-semibold mb-2">목록 (Waypoints + Memos)</h2>
+            <div id="itemList" class="border rounded p-2 overflow-auto flex-1 bg-gray-50"></div>
         </div>
     </div>
 </div>
@@ -94,36 +77,48 @@
 
 <script>
     let client = null;
-    let connected = false;
 
-    // ---------- 유틸 ----------
+    // ---------- 유틸리티 함수 ----------
     function log(message, type = "info") {
         const logBox = document.getElementById("log");
         const line = document.createElement("div");
-        line.className =
-            type === "success" ? "text-green-600"
-                : type === "error" ? "text-red-600"
-                    : type === "send" ? "text-blue-600"
-                        : "text-gray-800";
-        line.textContent = message;
+        const typeClasses = {
+            success: "text-green-600",
+            error: "text-red-600",
+            send: "text-blue-600",
+            info: "text-gray-800",
+        };
+        line.className = typeClasses[type] || typeClasses.info;
+        line.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
         logBox.appendChild(line);
         logBox.scrollTop = logBox.scrollHeight;
     }
 
     function parseOrNull(numStr) {
-        if (numStr === null || numStr === undefined) return null;
+        if (numStr === null || numStr === undefined || numStr.trim() === "") return null;
         const n = parseFloat(numStr);
-        return Number.isNaN(n) ? null : n;
+        return isNaN(n) ? null : n;
     }
 
-    function toLocalDatetimeInput(v) {
-        if (!v) return "";
-        return v.toString().slice(0, 16);
+    function toLocalDatetimeString(isoString) {
+        if (!isoString) return "";
+        // ISO 8601 형식에서 'YYYY-MM-DDTHH:mm' 부분만 잘라냅니다.
+        return isoString.toString().slice(0, 16);
     }
 
-    // ---------- 연결 ----------
+
+    // ---------- WebSocket 연결 관리 ----------
     function connect() {
         const planId = document.getElementById("planId").value;
+        if (!planId) {
+            alert("Plan ID를 입력해주세요.");
+            return;
+        }
+
+        if (client && client.connected) {
+            log("이미 연결되어 있습니다.", "info");
+            return;
+        }
 
         client = new StompJs.Client({
             webSocketFactory: () => new SockJS("http://localhost:8080/ws"),
@@ -131,16 +126,11 @@
         });
 
         client.onConnect = () => {
-            connected = true;
-            log("✅ Connected to WebSocket", "success");
-
-            // 플랜 단위 브로드캐스트 구독
+            log(`✅ Connected to WebSocket for Plan ID: ${planId}`, "success");
             client.subscribe(`/topic/plans/${planId}`, (msg) => {
                 log("📩 Received: " + msg.body, "info");
-                renderWaypoints(msg.body);
+                renderItems(msg.body);
             });
-
-            // ✅ 에러 메시지 구독 (서버에서 /user/queue/errors 로 보낸 경우)
             client.subscribe(`/user/queue/errors`, (msg) => {
                 log("❌ Error: " + msg.body, "error");
                 try {
@@ -150,13 +140,8 @@
                     alert("에러 발생!\n" + msg.body);
                 }
             });
-
-            // 접속 후 전체 동기화
-            initWaypoints();
+            initData(); // 연결 성공 시 데이터 초기화
         };
-
-        client.onWebSocketError = (err) => log("WebSocket error: " + err, "error");
-        client.onStompError = (frame) => log("Broker error: " + JSON.stringify(frame), "error");
 
         client.activate();
     }
@@ -164,21 +149,31 @@
     function disconnect() {
         if (client) {
             client.deactivate();
-            connected = false;
-            log("❌ Disconnected", "error");
+            log("🔌 Disconnected", "error");
+            client = null;
         }
     }
 
-    // ---------- 액션 ----------
-    function initWaypoints() {
+
+    // ---------- 서버 액션 요청 ----------
+    function publish(destination, body = null) {
+        if (!client || !client.connected) {
+            alert("먼저 연결해주세요.");
+            return;
+        }
+        const headers = body ? { "content-type": "application/json" } : {};
+        client.publish({ destination, body: body ? JSON.stringify(body) : null, headers });
+        const logMessage = `➡️ Sent to ${destination}` + (body ? `: ${JSON.stringify(body)}` : "");
+        log(logMessage, "send");
+    }
+
+    function initData() {
         const planId = document.getElementById("planId").value;
-        client.publish({ destination: `/app/plans/${planId}/waypoints/init` });
-        log("➡️ Sent init request", "send");
+        publish(`/app/plans/${planId}/init`);
     }
 
     function createWaypoint() {
         const planId = document.getElementById("planId").value;
-
         const waypoint = {
             name: document.getElementById("wpName").value,
             description: document.getElementById("wpDescription").value,
@@ -186,29 +181,16 @@
             startTime: document.getElementById("wpStartTime").value || null,
             endTime: document.getElementById("wpEndTime").value || null,
             locationCategory: document.getElementById("wpCategory").value || null,
-            xPosition: parseFloat(document.getElementById("wpX").value),
-            yPosition: parseFloat(document.getElementById("wpY").value)
+            xPosition: parseOrNull(document.getElementById("wpX").value),
+            yPosition: parseOrNull(document.getElementById("wpY").value),
         };
-
-        client.publish({
-            destination: `/app/plans/${planId}/waypoints/create`,
-            body: JSON.stringify(waypoint),
-            headers: { "content-type": "application/json" },
-        });
-        log("➡️ Sent create request: " + JSON.stringify(waypoint), "send");
-    }
-
-    function deleteWaypointById(waypointId) {
-        const planId = document.getElementById("planId").value;
-        client.publish({
-            destination: `/app/plans/${planId}/waypoints/${waypointId}/delete`,
-        });
-        log(`➡️ Sent delete request for waypointId=${waypointId}`, "send");
+        publish(`/app/plans/${planId}/waypoints/create`, waypoint);
     }
 
     function updateWaypointById(waypointId, card) {
+        const planId = document.getElementById("planId").value;
         const updatedWaypoint = {
-            name: card.querySelector(".wp-name").value,
+            name: card.querySelector(".item-name").value,
             description: card.querySelector(".wp-description").value,
             address: card.querySelector(".wp-address").value,
             startTime: card.querySelector(".wp-startTime").value || null,
@@ -217,19 +199,139 @@
             xPosition: parseOrNull(card.querySelector(".wp-x").value),
             yPosition: parseOrNull(card.querySelector(".wp-y").value),
         };
-
-        const planId = document.getElementById("planId").value;
-        client.publish({
-            destination: `/app/plans/${planId}/waypoints/${waypointId}/update`,
-            body: JSON.stringify(updatedWaypoint),
-            headers: { "content-type": "application/json" },
-        });
-        log("➡️ Sent update request: " + JSON.stringify(updatedWaypoint), "send");
+        publish(`/app/plans/${planId}/waypoints/${waypointId}/update`, updatedWaypoint);
     }
 
-    // ---------- 렌더링 ----------
-    function renderWaypoints(messageBody) {
-        const container = document.getElementById("waypointList");
+    function deleteWaypointById(waypointId) {
+        const planId = document.getElementById("planId").value;
+        publish(`/app/plans/${planId}/waypoints/${waypointId}/delete`);
+    }
+
+    function createMemo() {
+        const planId = document.getElementById("planId").value;
+        const memo = {
+            title: document.getElementById("memoTitle").value,
+            content: document.getElementById("memoContent").value,
+            xPosition: parseOrNull(document.getElementById("memoX").value),
+            yPosition: parseOrNull(document.getElementById("memoY").value),
+        };
+        publish(`/app/plans/${planId}/memos/create`, memo);
+    }
+
+    function updateMemoById(memoId, card) {
+        const planId = document.getElementById("planId").value;
+        const updatedMemo = {
+            title: card.querySelector(".item-name").value,
+            content: card.querySelector(".memo-content").value,
+            xPosition: parseOrNull(card.querySelector(".memo-x").value),
+            yPosition: parseOrNull(card.querySelector(".memo-y").value),
+        };
+        publish(`/app/plans/${planId}/memos/${memoId}/update`, updatedMemo);
+    }
+
+    function deleteMemoById(memoId) {
+        const planId = document.getElementById("planId").value;
+        publish(`/app/plans/${planId}/memos/${memoId}/delete`);
+    }
+
+
+    // ---------- 렌더링 로직 (리팩토링) ----------
+
+    /**
+     * Waypoint에 해당하는 HTML 입력 필드 문자열을 생성합니다.
+     * @param {object} wp - 웨이포인트 데이터 객체
+     * @returns {string} HTML 문자열
+     */
+    function createWaypointFields(wp) {
+        return `
+            <label class="flex flex-col text-sm">설명
+                <input class="wp-description border rounded p-2" value="${wp.description ?? ''}" />
+            </label>
+            <label class="flex flex-col text-sm">주소
+                <input class="wp-address border rounded p-2" value="${wp.address ?? ''}" />
+            </label>
+            <div class="grid grid-cols-2 gap-3 text-sm">
+                <label class="flex flex-col">시작 시간
+                    <input type="datetime-local" class="wp-startTime border rounded p-2" value="${toLocalDatetimeString(wp.startTime)}" />
+                </label>
+                <label class="flex flex-col">종료 시간
+                    <input type="datetime-local" class="wp-endTime border rounded p-2" value="${toLocalDatetimeString(wp.endTime)}" />
+                </label>
+            </div>
+            <div class="grid grid-cols-3 gap-3 text-sm">
+                <label class="flex flex-col">카테고리
+                    <select class="wp-category border rounded p-2">
+                        <option value="DEFAULT" ${wp.locationCategory === 'DEFAULT' ? 'selected' : ''}>DEFAULT</option>
+                        <option value="FOOD" ${wp.locationCategory === 'FOOD' ? 'selected' : ''}>FOOD</option>
+                        <option value="CULTURE" ${wp.locationCategory === 'CULTURE' ? 'selected' : ''}>CULTURE</option>
+                        <option value="ACCOMMODATION" ${wp.locationCategory === 'ACCOMMODATION' ? 'selected' : ''}>ACCOMMODATION</option>
+                        <option value="TOUR" ${wp.locationCategory === 'TOUR' ? 'selected' : ''}>TOUR</option>
+                        <option value="TRANSPORTATION" ${wp.locationCategory === 'TRANSPORTATION' ? 'selected' : ''}>TRANSPORTATION</option>
+                    </select>
+                </label>
+                <label class="flex flex-col">X 좌표
+                    <input type="number" step="0.01" class="wp-x border rounded p-2" value="${wp.xPosition ?? ''}" />
+                </label>
+                <label class="flex flex-col">Y 좌표
+                    <input type="number" step="0.01" class="wp-y border rounded p-2" value="${wp.yPosition ?? ''}" />
+                </label>
+            </div>
+        `;
+    }
+
+    /**
+     * Memo에 해당하는 HTML 입력 필드 문자열을 생성합니다.
+     * @param {object} memo - 메모 데이터 객체
+     * @returns {string} HTML 문자열
+     */
+    function createMemoFields(memo) {
+        return `
+            <label class="flex flex-col text-sm">내용
+                <input class="memo-content border rounded p-2" value="${memo.content ?? ''}" />
+            </label>
+            <div class="grid grid-cols-2 gap-3 text-sm">
+                <label class="flex flex-col">X 좌표
+                    <input type="number" step="0.01" class="memo-x border rounded p-2" value="${memo.xPosition ?? ''}" />
+                </label>
+                <label class="flex flex-col">Y 좌표
+                    <input type="number" step="0.01" class="memo-y border rounded p-2" value="${memo.yPosition ?? ''}" />
+                </label>
+            </div>
+        `;
+    }
+
+    /**
+     * 공통 카드 UI를 생성하는 범용 함수
+     * @param {object} config - 카드 생성에 필요한 설정 객체
+     * @returns {HTMLElement} 생성된 카드 div 엘리먼트
+     */
+    function createItemCard(config) {
+        const card = document.createElement("div");
+        card.className = `item-card ${config.type}-card border rounded p-4 bg-white shadow-sm mb-3 flex flex-col gap-3`;
+        card.innerHTML = `
+            <div class="flex justify-between items-start gap-2">
+                <div class="flex-1 flex items-center gap-2">
+                    <span class="text-xl">${config.icon}</span>
+                    <input class="item-name border rounded p-2 flex-1 font-bold ${config.titleClass}" value="${config.title ?? ''}" />
+                </div>
+                <div class="flex gap-1">
+                    <button onclick="${config.updateFn}(${config.id}, this.closest('.item-card'))"
+                        class="px-2 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm">수정</button>
+                    <button onclick="${config.deleteFn}(${config.id})"
+                        class="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm">삭제</button>
+                </div>
+            </div>
+            ${config.fieldsHtml}
+        `;
+        return card;
+    }
+
+    /**
+     * 서버로부터 받은 데이터로 Waypoint와 Memo 목록을 렌더링합니다.
+     * @param {string} messageBody - 서버에서 받은 JSON 문자열
+     */
+    function renderItems(messageBody) {
+        const container = document.getElementById("itemList");
         container.innerHTML = "";
 
         let payload;
@@ -240,68 +342,41 @@
             return;
         }
 
-        if (!payload || payload.type !== "FULL_UPDATE" || !Array.isArray(payload.waypoints)) {
-            return;
+        if (!payload || payload.type !== "FULL_UPDATE") return;
+
+        // Waypoints 렌더링
+        if (Array.isArray(payload.waypoints)) {
+            payload.waypoints.forEach((wp) => {
+                const card = createItemCard({
+                    type: 'waypoint',
+                    id: wp.id,
+                    icon: '📍',
+                    title: wp.name,
+                    titleClass: 'text-blue-600',
+                    fieldsHtml: createWaypointFields(wp),
+                    updateFn: 'updateWaypointById',
+                    deleteFn: 'deleteWaypointById'
+                });
+                container.appendChild(card);
+            });
         }
 
-        payload.waypoints.forEach((wp) => {
-            const card = document.createElement("div");
-            card.className = "wp-card border rounded p-4 bg-white shadow-sm mb-3 flex flex-col gap-3";
-
-            card.innerHTML = `
-        <div class="flex justify-between items-start gap-2">
-          <input class="wp-name border rounded p-2 flex-1 font-bold text-blue-600" value="${wp.name ?? ""}" />
-          <div class="flex gap-1">
-            <button
-              onclick="updateWaypointById(${wp.id}, this.closest('.wp-card'))"
-              class="px-2 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm"
-            >수정</button>
-            <button
-              onclick="deleteWaypointById(${wp.id})"
-              class="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm"
-            >삭제</button>
-          </div>
-        </div>
-
-        <label class="flex flex-col text-sm">
-          설명
-          <input class="wp-description border rounded p-2" value="${wp.description ?? ""}" />
-        </label>
-
-        <label class="flex flex-col text-sm">
-          주소
-          <input class="wp-address border rounded p-2" value="${wp.address ?? ""}" />
-        </label>
-
-        <div class="grid grid-cols-2 gap-3 text-sm">
-          <label class="flex flex-col">
-            시작 시간
-            <input type="datetime-local" class="wp-startTime border rounded p-2" value="${toLocalDatetimeInput(wp.startTime)}" />
-          </label>
-          <label class="flex flex-col">
-            종료 시간
-            <input type="datetime-local" class="wp-endTime border rounded p-2" value="${toLocalDatetimeInput(wp.endTime)}" />
-          </label>
-        </div>
-
-        <div class="grid grid-cols-3 gap-3 text-sm">
-          <label class="flex flex-col">
-            카테고리 (ENUM)
-            <input class="wp-category border rounded p-2" value="${wp.locationCategory ?? ""}" />
-          </label>
-          <label class="flex flex-col">
-            X 좌표
-            <input type="number" step="0.01" class="wp-x border rounded p-2" value="${wp.xPosition ?? ""}" />
-          </label>
-          <label class="flex flex-col">
-            Y 좌표
-            <input type="number" step="0.01" class="wp-y border rounded p-2" value="${wp.yPosition ?? ""}" />
-          </label>
-        </div>
-      `;
-
-            container.appendChild(card);
-        });
+        // Memos 렌더링
+        if (Array.isArray(payload.memos)) {
+            payload.memos.forEach((memo) => {
+                const card = createItemCard({
+                    type: 'memo',
+                    id: memo.id,
+                    icon: '📝',
+                    title: memo.title,
+                    titleClass: 'text-purple-700',
+                    fieldsHtml: createMemoFields(memo),
+                    updateFn: 'updateMemoById',
+                    deleteFn: 'deleteMemoById'
+                });
+                container.appendChild(card);
+            });
+        }
     }
 </script>
 </html>


### PR DESCRIPTION
# 📝 [develop ← feature/memo-api] Memo api 생성

## 관련된 ISSUE ( OPTIONAL )
- closed: #18 

## 요약
- [x] 기능 추가 : 계획 페이지에서 사용될 메모 CRUD API를 만들었습니다.
- [x] 리팩토링 : 이를 테스트할 수 있도록 web-socket.html을 수정했습니다.

## 얻어낸 효과
    사용자가 자유롭게 Memo CRUD가 가능해졌습니다.

## 궁금한 점

## Reference

## 해결할 문제
- 하나의 페이지에 모든 정보를 다 보여주기 위해서는 plan을 클라이언트가 구독 후 plan과 관련된 모든 데이터를 한 번에 넘겨줘야합니다.
    - 데이터의 양이 많아질수록 DB 접근도 늘어날 것입니다. 하지만 이는 캐싱으로 해결할 수 있을 것 같긴 하나, 프론트에서 렌더링 시간이 늘어나서 문제가 될 수 있을 것 같습니다.
    - 컴포넌트별로 업데이트가 될 때 마다 해당 컴포넌트만 새로 랜더링할 수 있게 api를 만들어야 할 듯 한데, 이는 스프린트 2에서 해결할 예정입니다.

## 추가 코멘트
- 이전에 Waypoint를 만든 것과 매우 유사하여 기능별로 커밋을 일일이 나누지 않고 한 번에 제작했습니다.
- 원래 Memo ID를 Waypoint와 Route에 매핑 시키기로 했으나, 프론트엔드와 잠깐 상의 후 일단 독립적인 컴포넌트로 두기로 했습니다.