### PR TITLE
[develop ← feature/#30] Github Actions Error 관련, 워크플로우 액션 버전 수정

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
 
       # 6. 빌드된 JAR 파일을 서버로 전송
       - name: Transfer Jar to Server
-        uses: appleboy/scp-action@releases/v1
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
@@ -46,7 +46,7 @@ jobs:
 
       # 7. 서버에 접속하여 배포 스크립트 실행
       - name: Execute Deploy Script on Server
-        uses: appleboy/ssh-action@releases/v1
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
## 관련된 ISSUE ( OPTIONAL )
- related: #30 , 이미 closed 된 상태임.

## 요약
- [ ] 버그 수정 : 워크플로우 실행 시 'Unable to resolve action' 에러가 발생하는 것을 확인. 원인은 `@releases/v1`이 더 이상 유효하지 않은 버전 태그이기 때문. 이를 최신 안정 버전을 가리키는 `@v1` 태그로 변경하여 문제를 해결함.


## 얻어낸 효과 ( OPTIONAL )
    Gemini는 최신 정보를 가지고 모든 판단을 하는 것이 아니기 때문에, 이러한 버전 부분은 공식 문서를 확인하며 작성하는 것이 좋은 습관인 것 같습니다.

## Reference
- https://github.com/appleboy/scp-action
- https://github.com/appleboy/ssh-action