### PR TITLE
[develop ← feature/#30] 배포 시 불필요한 디렉토리 구조 제거

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,6 +43,7 @@ jobs:
           port: 22
           source: "./build/libs/*.jar"
           target: "/home/ubuntu/JourneyPlanner/build"
+          strip_components: 2
 
       # 7. 서버에 접속하여 배포 스크립트 실행
       - name: Execute Deploy Script on Server


### PR DESCRIPTION
## 관련된 ISSUE ( OPTIONAL )
- closed: ex) 해당 블록에 작성 시, PR 시, ISSUE 가 닫힙니다.
- related:  ex) 해당 블록에 작성 시, PR 시, ISSUE 가 열린 상태입니다.

## 요약
- [x] 버그 수정
  - 배포 서버의 `/home/ubuntu/JourneyPlanner/build/` 디렉토리에 `.jar`파일이 저장되어야 하는데, `.../build/build/libs/*jar` 처럼 이상한 디렉토리 구조로 저장되는 현상이 발생.
  - Github Actions 설정 팡리의 scp-action 부분에 strip_components 옵션을 추가해 위 현상을 해결