### PR TITLE
[develop ← feature/#30] 데이터베이스 설정을 RDS MySQL로 전환

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,18 +3,25 @@ spring:
     import: optional:file:dev.env[.properties]
   application:
     name: JourneyPlanner
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        use_sql_comments: true
   datasource:
-    driver-class-name: org.h2.Driver
-    username: sa
-    password: test
-    url: jdbc:h2:mem:journey-planner;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: ${DRIVER_CLASS_NAME}
+    url: jdbc:mysql://${RDS_HOST}:${RDS_PORT}/${RDS_DB_NAME}
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+    hikari:
+      max-lifetime: 170000
   thymeleaf:
     prefix: classpath:/META-INF/templates
     suffix: .html
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
 
 jwt:
   secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 관련된 ISSUE ( OPTIONAL )
- related:  #30 , 이미 closed 된 상태임.

## 요약
- [x] 기능 추가
  - RDS 인스턴스 생성 : MySql 환경 설정 → 상세 주소 정보는 `dev.env` 파일에 기록되어 있음.

## 얻어낸 효과
  개발 및 향후 운영 환경에서 영구적인 데이터 저장을 위해 기존 H2 인메모리 DB 설정을 AWS RDS MySQL DB로 변경함.
