### PR TITLE
🧩[develop ← feature/webscoket-api-docs] bot 권한 부여

### DIFF
--- a/.github/workflows/asyncapi-docs.yml
+++ b/.github/workflows/asyncapi-docs.yml
@@ -11,6 +11,8 @@ jobs:
   # 문서 생성 및 커밋 작업
   build-and-commit-docs:
     runs-on: ubuntu-latest # 실행 환경
+    permissions:
+      contents: write
     steps:
       # 1. 저장소 코드 가져오기
       - name: Checkout Repository


### PR DESCRIPTION
# 🧩[develop ← feature/webscoket-api-docs] bot 권한 부여

## 관련된 ISSUE
- related:  #42 

## 요약 
- [x] 버그 수정 : github action bot이 레포지토리에 push할 권한이 없어 추가했습니다.

## 얻어낸 효과
- 문서 생성

## 궁금한 점
- None

## Reference
- None