### PR TITLE
🔨[develop ← feature/http-api-docs] HTTP API 명세 자동 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.kakaotechcampus'
@@ -77,9 +78,19 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	// * Swagger UI
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+}
+
+ext {
+	set('snippetsDir', file("build/generated-snippets"))
 }
 
 tasks.named('test') {
+	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+tasks.named('asciidoctor') {
+	inputs.dir snippetsDir
+	dependsOn test
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/config/SwaggerConfig.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.kakaotechcampus.journey_planner.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .servers(List.of(
+                        new Server().url("http://18.118.161.98:8080").description("Production HTTPS 서버"),
+                        new Server().url("http://localhost:8080").description("로컬 개발 서버")
+                ));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Journey Planner API")
+                .description("카카오테크캠퍼스 3기 경북대 4팀의 백엔드 API 명세")
+                .version("1.0.0");
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,13 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration-in-ms: ${JWT_ACCESS_TOKEN_EXPIRATION_IN} # 60000 : 1분
   refresh-token-expiration-in-ms: ${JWT_REFRESH_TOKEN_EXPIRATION_IN}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    tryItOutEnabled: true
+  default-produces-media-type: application/json


### PR DESCRIPTION
# 🔨[develop ← feature/http-api-docs] HTTP API 명세 자동 문서화

## 관련된 ISSUE
- related:  #43 

## 요약
- [x] 기능 추가 : Swagger 문서가 자동으로 생성될 수 있도록했습니다.

## 얻어낸 효과 ( OPTIONAL )
- API 자동 문서화로 프론트 <-> 백 간의 원활한 의사 소통

## 궁금한 점
- 지금은 디폴트 세팅인 상태인데, 추가적인 커스터마이징이 필요할까요?

## Reference
- http://18.118.161.98:8080/swagger-ui/index.html