### PR TITLE
[develop ← feature/kafka-adoption] Member 에 따른 Plan 전체 불러오기 기능 + Cors 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -35,8 +35,8 @@ public class PlanService {
     }
 
     @Transactional(readOnly = true)
-    public List<PlanResponse> getAllPlans() {
-        return PlanMapper.toResponseList(planRepository.findAll());
+    public List<PlanResponse> getAllPlans(Long userId) {
+        return PlanMapper.toResponseList(planRepository.getAllPlanByUserId());
     }
 
     @Transactional

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
+import com.kakaotechcampus.journey_planner.domain.member.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -29,6 +30,9 @@ public class Plan {
 
     @NotNull(message = "종료일은 필수 값입니다.")
     private LocalDate endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 
     public Plan(String title, String description, LocalDate startDate, LocalDate endDate) {
         this.title = title;

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/PlanRepository.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/PlanRepository.java
@@ -1,6 +1,12 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+    @Query("SELECT p FROM Plan p WHERE p.member.id=:userId")
+    public List<Plan> getAllPlanByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebMvcConfig.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebMvcConfig.java
@@ -9,7 +9,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("https://journey-planner-deployment.vercel.app/")
+                .allowedOrigins("http://localhost:5173")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/resolver/LoginMemberArgumentResolver.java
@@ -7,6 +7,7 @@ import com.kakaotechcampus.journey_planner.global.exception.BusinessException;
 import com.kakaotechcampus.journey_planner.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -34,7 +35,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String authorizationHeader = request.getHeader("Authorization");
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
         String token = extractToken(authorizationHeader);
         String email = jwtProvider.extractEmailFromAccessToken(token);
         return memberService.findByEmail(email)

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -1,6 +1,8 @@
 package com.kakaotechcampus.journey_planner.presentation.plan;
 
 import com.kakaotechcampus.journey_planner.application.plan.PlanService;
+import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.global.annotation.LoginMember;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.CreatePlanRequest;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.PlanResponse;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.UpdatePlanRequest;
@@ -34,8 +36,8 @@ public class PlanController {
 
     // Plan 전체 조회
     @GetMapping
-    public ResponseEntity<List<PlanResponse>> getAllPlans() {
-        List<PlanResponse> response = planService.getAllPlans();
+    public ResponseEntity<List<PlanResponse>> getAllPlans(@LoginMember Member member) {
+        List<PlanResponse> response = planService.getAllPlans(member.getId());
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
# [develop ← feature/kafka-adoption] Member 에 따른 Plan 전체 불러오기 기능 + Cors 수정

## 요약
- [x] 기능 추가 : Member 에 따른 Plan 전체 불러오기 기능
- [x] 버그 수정 : Cors 수정
- [x] 리팩토링: "Authorization" 으로 되어있는 문자열을 HttpStatus.Authorizaiton 으로 변경 ( 스프링에서 제공하는 정적값 사용 )