### PR TITLE
[develop ← feature/#34] 프라이빗 계획 페이지 : 계획을 열람할 수 있는 권한 설정 및 사용자 초대 / 수락 기능 구현

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/application/memberplan/MemberPlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/memberplan/MemberPlanService.java
@@ -1,0 +1,22 @@
+package com.kakaotechcampus.journey_planner.application.memberplan;
+
+import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlanRepository;
+import com.kakaotechcampus.journey_planner.domain.plan.Plan;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberPlanService {
+    private final MemberPlanRepository memberPlanRepository;
+
+    @Transactional
+    public MemberPlan createMemberPlan(Member member, Plan plan) {
+        MemberPlan memberPlan = new MemberPlan(member, plan);
+        MemberPlan savedMemberPlan = memberPlanRepository.save(memberPlan);
+        return savedMemberPlan;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/memberplan/MemberPlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/memberplan/MemberPlanService.java
@@ -15,7 +15,7 @@ public class MemberPlanService {
 
     @Transactional
     public MemberPlan createMemberPlan(Member member, Plan plan) {
-        MemberPlan memberPlan = new MemberPlan(member, plan);
+        MemberPlan memberPlan = MemberPlan.createPlan(member, plan);
         MemberPlan savedMemberPlan = memberPlanRepository.save(memberPlan);
         return savedMemberPlan;
     }

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -1,5 +1,8 @@
 package com.kakaotechcampus.journey_planner.application.plan;
 
+import com.kakaotechcampus.journey_planner.application.memberplan.MemberPlanService;
+import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
 import com.kakaotechcampus.journey_planner.domain.plan.Plan;
 import com.kakaotechcampus.journey_planner.domain.plan.PlanMapper;
 import com.kakaotechcampus.journey_planner.domain.plan.PlanRepository;
@@ -19,11 +22,15 @@ import java.util.List;
 public class PlanService {
 
     private final PlanRepository planRepository;
+    private final MemberPlanService memberPlanService;
 
     @Transactional
-    public PlanResponse createPlan(CreatePlanRequest request) {
+    public PlanResponse createPlan(Member member, CreatePlanRequest request) {
         Plan plan = PlanMapper.toEntity(request);
         Plan savedPlan = planRepository.save(plan);
+        MemberPlan savedMemberPlan = memberPlanService.createMemberPlan(member, savedPlan);
+        member.addMemberPlan(savedMemberPlan);
+        plan.addMemberPlan(savedMemberPlan);
         return PlanMapper.toResponse(savedPlan);
     }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -55,10 +55,17 @@ public class PlanService {
     }
 
     @Transactional
-    public PlanResponse updatePlan(Long id, UpdatePlanRequest request) {
+    public PlanResponse updatePlan(Member member, Long id, UpdatePlanRequest request) {
         Plan plan = planRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
 
+        boolean isMemberInPlan = plan.getMemberPlans().stream()
+                .map(MemberPlan::getMember)
+                .anyMatch(planMember -> planMember.equals(member));
+
+        if (!isMemberInPlan) {
+            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED); // 예시 ErrorCode
+        }
         plan.update(
                 request.title(),
                 request.description(),

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -38,13 +38,9 @@ public class PlanService {
     public PlanResponse getPlan(Member member, Long planId) {
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
-
-        boolean isMemberInPlan = plan.getMemberPlans().stream()
-                .map(MemberPlan::getMember)
-                .anyMatch(planMember -> planMember.equals(member));
-
+        boolean isMemberInPlan = plan.hasMember(member);
         if (!isMemberInPlan) {
-            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED); // 예시 ErrorCode
+            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED);
         }
         return PlanMapper.toResponse(plan);
     }
@@ -58,13 +54,9 @@ public class PlanService {
     public PlanResponse updatePlan(Member member, Long id, UpdatePlanRequest request) {
         Plan plan = planRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
-
-        boolean isMemberInPlan = plan.getMemberPlans().stream()
-                .map(MemberPlan::getMember)
-                .anyMatch(planMember -> planMember.equals(member));
-
+        boolean isMemberInPlan = plan.hasMember(member);
         if (!isMemberInPlan) {
-            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED); // 예시 ErrorCode
+            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED);
         }
         plan.update(
                 request.title(),

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -69,9 +69,13 @@ public class PlanService {
     }
 
     @Transactional
-    public void deletePlan(Long id) {
+    public void deletePlan(Member member, Long id) {
         Plan plan = planRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+        boolean isMemberInPlan = plan.hasMember(member);
+        if (!isMemberInPlan) {
+            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED);
+        }
         planRepository.delete(plan);
     }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -35,9 +35,17 @@ public class PlanService {
     }
 
     @Transactional(readOnly = true)
-    public PlanResponse getPlan(Long id) {
-        Plan plan = planRepository.findById(id)
+    public PlanResponse getPlan(Member member, Long planId) {
+        Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+
+        boolean isMemberInPlan = plan.getMemberPlans().stream()
+                .map(MemberPlan::getMember)
+                .anyMatch(planMember -> planMember.equals(member));
+
+        if (!isMemberInPlan) {
+            throw new BusinessException(ErrorCode.PLAN_ACCESS_DENIED); // 예시 ErrorCode
+        }
         return PlanMapper.toResponse(plan);
     }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -26,7 +26,7 @@ public class PlanService {
 
     @Transactional
     public PlanResponse createPlan(Member member, CreatePlanRequest request) {
-        Plan plan = PlanMapper.toEntity(request);
+        Plan plan = PlanMapper.toEntity(request, member);
         Plan savedPlan = planRepository.save(plan);
         MemberPlan savedMemberPlan = memberPlanService.createMemberPlan(member, savedPlan);
         member.addMemberPlan(savedMemberPlan);

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -2,7 +2,10 @@ package com.kakaotechcampus.journey_planner.application.plan;
 
 import com.kakaotechcampus.journey_planner.application.memberplan.MemberPlanService;
 import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.domain.member.MemberRepository;
+import com.kakaotechcampus.journey_planner.domain.memberplan.InvitationStatus;
 import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlanRepository;
 import com.kakaotechcampus.journey_planner.domain.plan.Plan;
 import com.kakaotechcampus.journey_planner.domain.plan.PlanMapper;
 import com.kakaotechcampus.journey_planner.domain.plan.PlanRepository;
@@ -106,5 +109,20 @@ public class PlanService {
 
         MemberPlan invitation = MemberPlan.createInvitation(invitee, plan);
         memberPlanRepository.save(invitation);
+    }
+
+    @Transactional
+    public void acceptInvitation(Member accepter, Long invitationId) {
+        MemberPlan invitation = memberPlanRepository.findById(invitationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVITATION_NOT_FOUND));
+        if (!invitation.getMember().equals(accepter)) {
+            throw new BusinessException(ErrorCode.INVITATION_ACCESS_DENIED);
+        }
+
+        if (invitation.getStatus() != InvitationStatus.INVITED) {
+            throw new BusinessException(ErrorCode.INVITATION_ALREADY_PROCESSED);
+        }
+
+        invitation.accept();
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/plan/PlanService.java
@@ -5,6 +5,7 @@ import com.kakaotechcampus.journey_planner.domain.member.Member;
 import com.kakaotechcampus.journey_planner.domain.member.MemberRepository;
 import com.kakaotechcampus.journey_planner.domain.memberplan.InvitationStatus;
 import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlanMapper;
 import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlanRepository;
 import com.kakaotechcampus.journey_planner.domain.plan.Plan;
 import com.kakaotechcampus.journey_planner.domain.plan.PlanMapper;
@@ -12,6 +13,7 @@ import com.kakaotechcampus.journey_planner.domain.plan.PlanRepository;
 import com.kakaotechcampus.journey_planner.global.exception.BusinessException;
 import com.kakaotechcampus.journey_planner.global.exception.ErrorCode;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.CreatePlanRequest;
+import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.InvitationResponse;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.PlanResponse;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.UpdatePlanRequest;
 import lombok.RequiredArgsConstructor;
@@ -124,5 +126,11 @@ public class PlanService {
         }
 
         invitation.accept();
+    }
+
+    @Transactional(readOnly = true)
+    public List<InvitationResponse> getInvitations(Member member) {
+        List<MemberPlan> invitations = memberPlanRepository.findByMemberAndStatus(member, InvitationStatus.INVITED);
+        return MemberPlanMapper.toInvitationResponse(invitations);
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/member/Member.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/member/Member.java
@@ -1,11 +1,15 @@
 package com.kakaotechcampus.journey_planner.domain.member;
 
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "members")
@@ -26,7 +30,11 @@ public class Member {
     @Setter
     private String password;
 
+    @Enumerated(EnumType.STRING)
     private MbtiType mbtiType;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<MemberPlan> memberPlans = new ArrayList<>();
 
     public Member(String name, String contact, String email, String password, String mbti) {
         this.name = name;
@@ -42,6 +50,10 @@ public class Member {
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);
+    }
+
+    public void addMemberPlan(MemberPlan memberPlan) {
+        memberPlans.add(memberPlan);
     }
 }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/InvitationStatus.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/InvitationStatus.java
@@ -1,0 +1,5 @@
+package com.kakaotechcampus.journey_planner.domain.memberplan;
+
+public enum InvitationStatus {
+    INVITED, ACCEPTED, DECLINED
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class MemberPlan {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_plan_id")
-    private Long memberPlanId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
@@ -24,11 +24,26 @@ public class MemberPlan {
     @JoinColumn(name = "plan_id")
     private Plan plan;
 
-    public MemberPlan(Member member, Plan plan) {
-        this.member = member;
-        this.plan = plan;
     @Enumerated(EnumType.STRING)
     private InvitationStatus status;
 
+    public static MemberPlan createPlan(Member member, Plan plan) {
+        MemberPlan memberPlan = new MemberPlan();
+        memberPlan.member = member;
+        memberPlan.plan = plan;
+        memberPlan.status = InvitationStatus.ACCEPTED;
+        return memberPlan;
+    }
+
+    public static MemberPlan createInvitation(Member member, Plan plan) {
+        MemberPlan memberPlan = new MemberPlan();
+        memberPlan.member = member;
+        memberPlan.plan = plan;
+        memberPlan.status = InvitationStatus.INVITED;
+        return memberPlan;
+    }
+
+    public void accept() {
+        status = InvitationStatus.ACCEPTED;
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
@@ -1,0 +1,31 @@
+package com.kakaotechcampus.journey_planner.domain.memberplan;
+
+import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.domain.plan.Plan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_plan")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberPlan {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_plan_id")
+    private Long memberPlanId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    public MemberPlan(Member member, Plan plan) {
+        this.member = member;
+        this.plan = plan;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlan.java
@@ -27,5 +27,8 @@ public class MemberPlan {
     public MemberPlan(Member member, Plan plan) {
         this.member = member;
         this.plan = plan;
+    @Enumerated(EnumType.STRING)
+    private InvitationStatus status;
+
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlanMapper.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlanMapper.java
@@ -1,0 +1,19 @@
+package com.kakaotechcampus.journey_planner.domain.memberplan;
+
+import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.InvitationResponse;
+
+import java.util.List;
+
+public class MemberPlanMapper {
+    public static List<InvitationResponse> toInvitationResponse(List<MemberPlan> memberPlans) {
+        return memberPlans.stream()
+                .map(memberPlan -> new InvitationResponse(
+                        memberPlan.getPlan().getId(),
+                        memberPlan.getPlan().getTitle(),
+                        memberPlan.getPlan().getOrganizer().getName(),
+                        memberPlan.getId(),
+                        memberPlan.getStatus().toString()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlanRepository.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlanRepository.java
@@ -1,6 +1,10 @@
 package com.kakaotechcampus.journey_planner.domain.memberplan;
 
+import com.kakaotechcampus.journey_planner.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberPlanRepository extends JpaRepository<MemberPlan, Long> {
+    List<MemberPlan> findByMemberAndStatus(Member member, InvitationStatus status);
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlanRepository.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/memberplan/MemberPlanRepository.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.journey_planner.domain.memberplan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPlanRepository extends JpaRepository<MemberPlan, Long> {
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -34,14 +34,19 @@ public class Plan {
     @NotNull(message = "종료일은 필수 값입니다.")
     private LocalDate endDate;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organizer_id")
+    private Member organizer;
+
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<MemberPlan> memberPlans = new ArrayList<>();
 
-    public Plan(String title, String description, LocalDate startDate, LocalDate endDate) {
+    public Plan(String title, String description, LocalDate startDate, LocalDate endDate, Member organizer) {
         this.title = title;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.organizer = organizer;
     }
 
     public void update(String title, String description, LocalDate startDate, LocalDate endDate) {
@@ -59,5 +64,9 @@ public class Plan {
         return this.memberPlans.stream()
                 .map(MemberPlan::getMember)
                 .anyMatch(planMember -> planMember.equals(member));
+    }
+
+    public boolean isOrganizer(Member member) {
+        return this.organizer.equals(member);
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
+import com.kakaotechcampus.journey_planner.domain.member.Member;
 import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -52,5 +53,11 @@ public class Plan {
 
     public void addMemberPlan(MemberPlan memberPlan) {
         memberPlans.add(memberPlan);
+    }
+
+    public boolean hasMember(Member member) {
+        return this.memberPlans.stream()
+                .map(MemberPlan::getMember)
+                .anyMatch(planMember -> planMember.equals(member));
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -22,6 +22,7 @@ public class Plan {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
     private Long id;
 
     @NotBlank(message = "제목은 비어 있을 수 없습니다.")

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
+import com.kakaotechcampus.journey_planner.domain.memberplan.MemberPlan;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,6 +33,9 @@ public class Plan {
     @NotNull(message = "종료일은 필수 값입니다.")
     private LocalDate endDate;
 
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<MemberPlan> memberPlans = new ArrayList<>();
+
     public Plan(String title, String description, LocalDate startDate, LocalDate endDate) {
         this.title = title;
         this.description = description;
@@ -42,5 +48,9 @@ public class Plan {
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    public void addMemberPlan(MemberPlan memberPlan) {
+        memberPlans.add(memberPlan);
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/PlanMapper.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/PlanMapper.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
+import com.kakaotechcampus.journey_planner.domain.member.Member;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.CreatePlanRequest;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.PlanResponse;
 
@@ -8,12 +9,13 @@ import java.util.stream.Collectors;
 
 public class PlanMapper {
 
-    public static Plan toEntity(CreatePlanRequest request) {
+    public static Plan toEntity(CreatePlanRequest request, Member organizer) {
         return new Plan(
                 request.title(),
                 request.description(),
                 request.startDate(),
-                request.endDate());
+                request.endDate(),
+                organizer);
     }
 
     public static PlanResponse toResponse(Plan plan) {

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebConfig.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.kakaotechcampus.journey_planner.global.config;
+
+import com.kakaotechcampus.journey_planner.global.resolver.LoginMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode {
     // * PLAN
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_NOT_FOUND", "해당 계획을 찾을 수 없습니다."),
     PLAN_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "PLAN_ACCESS_DENIED", "해당 계획에 접근할 권한이 없습니다."),
-
+    MEMBER_ALREADY_IN_PLAN(HttpStatus.BAD_REQUEST, "MEMBER_ALREADY_IN_PLAN", "해당 계획에 이미 참여 중입니다."),
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITATION_NOT_FOUND", "해당 초대장이 존재하지 않습니다."),
+    INVITATION_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "INVITATION_ACCESS_DENIED", "해당 초대장에 접근할 권한이 없습니다."),
+    INVITATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "INVITATION_ALREADY_PROCESSED", "이미 승인된 초대장 입니다."),
     // * Resource
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO_RESOURCE", "리소스를 찾을 수 없습니다."),
     FONT_NOT_FOUND(HttpStatus.NOT_FOUND, "NO_FONT_RESOURCE", "폰트를 찾을 수 없습니다."),

--- a/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
     // * PLAN
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_NOT_FOUND", "해당 계획을 찾을 수 없습니다."),
+    PLAN_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "PLAN_ACCESS_DENIED", "해당 계획에 접근할 권한이 없습니다."),
 
     // * Resource
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "NO_RESOURCE", "리소스를 찾을 수 없습니다."),

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -1,6 +1,8 @@
 package com.kakaotechcampus.journey_planner.presentation.plan;
 
 import com.kakaotechcampus.journey_planner.application.plan.PlanService;
+import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.global.annotation.LoginMember;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.CreatePlanRequest;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.PlanResponse;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.UpdatePlanRequest;
@@ -8,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController
@@ -19,8 +22,11 @@ public class PlanController {
 
     // Plan 생성
     @PostMapping
-    public ResponseEntity<PlanResponse> createPlan(@Valid @RequestBody CreatePlanRequest request) {
-        PlanResponse response = planService.createPlan(request);
+    public ResponseEntity<PlanResponse> createPlan(
+            @LoginMember Member member,
+            @Valid @RequestBody CreatePlanRequest request
+    ) {
+        PlanResponse response = planService.createPlan(member, request);
         return ResponseEntity.status(201).body(response);
     }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -60,8 +60,11 @@ public class PlanController {
 
     // Plan 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePlan(@PathVariable Long id) {
-        planService.deletePlan(id);
+    public ResponseEntity<Void> deletePlan(
+            @LoginMember Member member,
+            @PathVariable Long id
+    ) {
+        planService.deletePlan(member, id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -32,8 +32,11 @@ public class PlanController {
 
     // Plan 단건 조회
     @GetMapping("/{id}")
-    public ResponseEntity<PlanResponse> getPlan(@PathVariable Long id) {
-        PlanResponse response = planService.getPlan(id);
+    public ResponseEntity<PlanResponse> getPlan(
+            @LoginMember Member member,
+            @PathVariable Long id
+    ) {
+        PlanResponse response = planService.getPlan(member, id);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -50,10 +50,11 @@ public class PlanController {
     // Plan 수정
     @PatchMapping("/{id}")
     public ResponseEntity<PlanResponse> updatePlan(
+            @LoginMember Member member,
             @PathVariable Long id,
             @Valid @RequestBody UpdatePlanRequest request
     ) {
-        PlanResponse response = planService.updatePlan(id, request);
+        PlanResponse response = planService.updatePlan(member, id, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -8,6 +8,7 @@ import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.PlanRe
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.UpdatePlanRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -78,4 +79,12 @@ public class PlanController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @PostMapping("/invitations/{invitationId}/accept")
+    public ResponseEntity<Void> acceptInvitation(
+            @LoginMember Member member,
+            @PathVariable Long invitationId
+    ) {
+        planService.acceptInvitation(member, invitationId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -4,6 +4,7 @@ import com.kakaotechcampus.journey_planner.application.plan.PlanService;
 import com.kakaotechcampus.journey_planner.domain.member.Member;
 import com.kakaotechcampus.journey_planner.global.annotation.LoginMember;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.CreatePlanRequest;
+import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.InvitationResponse;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.response.PlanResponse;
 import com.kakaotechcampus.journey_planner.presentation.plan.dto.request.UpdatePlanRequest;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -86,5 +88,13 @@ public class PlanController {
     ) {
         planService.acceptInvitation(member, invitationId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/invitations")
+    public ResponseEntity<List<InvitationResponse>> getInvitations(
+            @LoginMember Member member
+    ) {
+        List<InvitationResponse> invitations = planService.getInvitations(member);
+        return ResponseEntity.status(HttpStatus.OK).body(invitations);
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/PlanController.java
@@ -67,4 +67,15 @@ public class PlanController {
         planService.deletePlan(member, id);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/invitations/{planId}")
+    public ResponseEntity<Void> inviteMember(
+            @LoginMember Member member,
+            @PathVariable Long planId,
+            @RequestParam("email") String inviteeEmail
+    ){
+        planService.inviteMember(member, planId, inviteeEmail);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/dto/response/InvitationResponse.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/plan/dto/response/InvitationResponse.java
@@ -1,0 +1,10 @@
+package com.kakaotechcampus.journey_planner.presentation.plan.dto.response;
+
+public record InvitationResponse(
+        Long planId,
+        String planTitle,
+        String planOrganizerName,
+        Long invitationId,
+        String status
+) {
+}


### PR DESCRIPTION
## 관련된 ISSUE
- closed: #34 

## 요약
- [x] 기능 추가 : 
  - [x] 권한이 없는 사용자는 Plan을 열람할 수 없게 함.
  - [x] 계획에 사용자를 초대 / 수락할 수 있게 함. (계획을 만든 사람만 초대할 수 있게 설정하였음.)
  - [x] 사용자 본인이 받은 초대장을 한 번에 열람할 수 있는 기능.
- [x] 버그 수정 : `@LoginMember` 어노테이션이 작동하지 않음. → 작성한 LoginMemberArgumentResolver 를 스프링 Argument Resolver에 추가하지 않았기 때문이었음.
- [x] 리팩토링
  1. `MemberPlan` 객체의 생성자 대신 정적 펙터리 메서드를 이용하였음.
  2. 이 사용자가 (1) 이 계획에 참여하고 있는지, (2) 이 계획을 만든 사람인지 판단하는 로직을 Plan 엔티티 코드에 추가함으로써, 다른 클래스에서 Plan 객체에 위 내용을 물어볼 수 있도록 설계함. → 객체 지향성을 높임.

## 궁금한 점
- 생성자 대신 정적 팩터리 메서드를 사용하는 것의 이점
  - 메서드 이름을 의미있게 지을 수 있다. → 같은 매개변수를 이용하지만 의미가 다른 객체를 생성할 수 있게 되고, 코드를 읽었을 때 직관적이게 된다.
  이러한 이점을 보고 MemberPlan 객체의 생성자를 삭제하고 정적 팩터리 메서드를 2개 만들어 사용했습니다.
  이런 접근이 괜찮은 생각인지? 혹시 제가 놓치고 있는 정적 팩터리 메서드의 단점이 있는지 궁금합니다!

## 코멘트

- 이번에 코드 작성하면서 기존에 작성돼있던 코드를 수정했는데, 팀 코드 작성 규율에 맞는 수정인지 판단해주시면 감사하겠습니다!
  - `Plan.java` : organizer 필드 추가, MemberPlan 테이블과의 매핑 관계 추가, hasMember()과 같이 boolean 값을 반환하는 메서드 추가
  - `MemberPlan.java` : 인자를 받는 생성자 삭제 후 정적 팩터리 메서드 2개 추가
