### PR TITLE
[develop← Feature/plan relations cascade] Plan의 연관관계된 도메인 cascade 추가

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/application/memo/MemoService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/memo/MemoService.java
@@ -29,9 +29,9 @@ public class MemoService {
     @Transactional
     public MemoResponse createMemo(Long planId, MemoRequest request) {
         Memo memo = MemoMapper.toEntity(request);
-
         Plan plan = planService.getPlanEntity(planId);
-        memo.assignToPlan(plan);
+
+        plan.addMemo(memo);
         assignTarget(memo, request);
         Memo savedMemo = memoRepository.save(memo);
 
@@ -60,7 +60,8 @@ public class MemoService {
         Memo memo = memoRepository.findByIdAndPlanId(memoId, planId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMO_NOT_FOUND));
 
-        memoRepository.delete(memo);
+        Plan plan = memo.getPlan();
+        plan.removeMemo(memo); // Plan 컬렉션에서 제거 → orphanRemoval 덕분에 DB에서도 삭제
     }
 
     public List<MemoResponse> getMemos(Long planId) {

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/route/RouteService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/route/RouteService.java
@@ -36,6 +36,9 @@ public class RouteService {
 
         Route route = RouteMapper.toEntity(plan, fromWaypoint, toWaypoint, request);
 
+        // ✅ Plan이 Route 생명주기 관리
+        plan.addRoute(route);
+
         Route savedRoute = routeRepository.save(route);
         return RouteMapper.toResponse(savedRoute);
     }
@@ -62,10 +65,12 @@ public class RouteService {
 
     @Transactional
     public void deleteRoute(Long planId, Long routeId) {
+        Plan plan = planService.getPlanEntity(planId);
         Route route = routeRepository.findByIdAndPlanId(routeId, planId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROUTE_NOT_FOUND));
 
-        routeRepository.delete(route);
+        // Plan이 Route 삭제 관리 (orphanRemoval 전파됨)
+        plan.removeRoute(route);
     }
 
     // planId에 속한 모든 route 조회

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/route/RouteService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/route/RouteService.java
@@ -36,7 +36,7 @@ public class RouteService {
 
         Route route = RouteMapper.toEntity(plan, fromWaypoint, toWaypoint, request);
 
-        // ✅ Plan이 Route 생명주기 관리
+        // Plan이 Route 생명주기 관리
         plan.addRoute(route);
 
         Route savedRoute = routeRepository.save(route);

--- a/src/main/java/com/kakaotechcampus/journey_planner/application/waypoint/WaypointService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/waypoint/WaypointService.java
@@ -30,8 +30,8 @@ public class WaypointService {
 
         Plan plan = planService.getPlanEntity(planId);
 
-        // 단방향: Waypoint 쪽에 Plan을 세팅
-        waypoint.assignToPlan(plan);
+        // 양방향 편의 메서드 사용
+        plan.addWaypoint(waypoint);
         Waypoint savedWaypoint = waypointRepository.save(waypoint);
 
         return WaypointMapper.toResponse(savedWaypoint);
@@ -61,10 +61,13 @@ public class WaypointService {
     // planId 및 waypointId에 해당하는 waypoint 삭제
     @Transactional
     public void deleteWaypoint(Long planId, Long waypointId) {
+        Plan plan = planService.getPlanEntity(planId);
+
         Waypoint waypoint = waypointRepository.findByIdAndPlanId(waypointId, planId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WAYPOINT_NOT_FOUND));
 
-        waypointRepository.delete(waypoint);
+        //orphanRemoval=true → 컬렉션에서만 제거하면 DB에서도 삭제됨
+        plan.removeWaypoint(waypoint);
     }
 
     // planId에 속한 모든 waypoint 조회

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -2,6 +2,7 @@ package com.kakaotechcampus.journey_planner.domain.plan;
 
 import com.kakaotechcampus.journey_planner.domain.member.Member;
 import com.kakaotechcampus.journey_planner.domain.traveler.Traveler;
+import com.kakaotechcampus.journey_planner.domain.waypoint.Waypoint;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -38,6 +39,10 @@ public class Plan {
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Traveler> travelers = new ArrayList<>();
 
+
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Waypoint> waypoints = new ArrayList<>();
+
     public Plan(String title, String description, LocalDate startDate, LocalDate endDate) {
         this.title = title;
         this.description = description;
@@ -60,5 +65,15 @@ public class Plan {
         return this.travelers.stream()
                 .map(Traveler::getMember)
                 .anyMatch(planMember -> planMember.equals(member));
+    }
+
+    public void addWaypoint(Waypoint waypoint) {
+        waypoints.add(waypoint);
+        waypoint.assignToPlan(this);
+    }
+
+    public void removeWaypoint(Waypoint waypoint) {
+        waypoints.remove(waypoint);
+        waypoint.assignToPlan(null);
     }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -1,6 +1,7 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
 import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.domain.route.Route;
 import com.kakaotechcampus.journey_planner.domain.traveler.Traveler;
 import com.kakaotechcampus.journey_planner.domain.waypoint.Waypoint;
 import jakarta.persistence.*;
@@ -43,6 +44,20 @@ public class Plan {
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Waypoint> waypoints = new ArrayList<>();
 
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Route> routes = new ArrayList<>();
+
+    public void addRoute(Route route) {
+        routes.add(route);
+        route.assignToPlan(this);
+    }
+
+    public void removeRoute(Route route) {
+        routes.remove(route);
+        route.assignToPlan(null);
+    }
+
+
     public Plan(String title, String description, LocalDate startDate, LocalDate endDate) {
         this.title = title;
         this.description = description;
@@ -76,4 +91,5 @@ public class Plan {
         waypoints.remove(waypoint);
         waypoint.assignToPlan(null);
     }
+
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/plan/Plan.java
@@ -1,6 +1,7 @@
 package com.kakaotechcampus.journey_planner.domain.plan;
 
 import com.kakaotechcampus.journey_planner.domain.member.Member;
+import com.kakaotechcampus.journey_planner.domain.memo.Memo;
 import com.kakaotechcampus.journey_planner.domain.route.Route;
 import com.kakaotechcampus.journey_planner.domain.traveler.Traveler;
 import com.kakaotechcampus.journey_planner.domain.waypoint.Waypoint;
@@ -40,22 +41,14 @@ public class Plan {
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Traveler> travelers = new ArrayList<>();
 
-
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Waypoint> waypoints = new ArrayList<>();
 
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Route> routes = new ArrayList<>();
 
-    public void addRoute(Route route) {
-        routes.add(route);
-        route.assignToPlan(this);
-    }
-
-    public void removeRoute(Route route) {
-        routes.remove(route);
-        route.assignToPlan(null);
-    }
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Memo> memos = new ArrayList<>();
 
 
     public Plan(String title, String description, LocalDate startDate, LocalDate endDate) {
@@ -90,6 +83,26 @@ public class Plan {
     public void removeWaypoint(Waypoint waypoint) {
         waypoints.remove(waypoint);
         waypoint.assignToPlan(null);
+    }
+
+    public void addRoute(Route route) {
+        routes.add(route);
+        route.assignToPlan(this);
+    }
+
+    public void removeRoute(Route route) {
+        routes.remove(route);
+        route.assignToPlan(null);
+    }
+
+    public void addMemo(Memo memo) {
+        memos.add(memo);
+        memo.assignToPlan(this);
+    }
+
+    public void removeMemo(Memo memo) {
+        memos.remove(memo);
+        memo.assignToPlan(null);
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/route/Route.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/route/Route.java
@@ -75,4 +75,12 @@ public class Route {
     public void assignToPlan(Plan plan) {
         this.plan = plan;
     }
+    // ✅ 연관관계 편의 메서드
+    public void setFromWayPoint(Waypoint fromWayPoint) {
+        this.fromWayPoint = fromWayPoint;
+    }
+
+    public void setToWayPoint(Waypoint toWayPoint) {
+        this.toWayPoint = toWayPoint;
+    }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/route/Route.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/route/Route.java
@@ -72,4 +72,7 @@ public class Route {
         this.durationMin = duration;
         this.vehicleCategory = vehicleCategory;
     }
+    public void assignToPlan(Plan plan) {
+        this.plan = plan;
+    }
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/domain/waypoint/Waypoint.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/domain/waypoint/Waypoint.java
@@ -1,6 +1,7 @@
 package com.kakaotechcampus.journey_planner.domain.waypoint;
 
 import com.kakaotechcampus.journey_planner.domain.plan.Plan;
+import com.kakaotechcampus.journey_planner.domain.route.Route;
 import com.kakaotechcampus.journey_planner.global.exception.BusinessException;
 import com.kakaotechcampus.journey_planner.global.exception.ErrorCode;
 import jakarta.persistence.*;
@@ -9,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,6 +45,14 @@ public class Waypoint {
 
     private Float xPosition;
     private Float yPosition;
+
+    // fromWayPoint로 연결된 Route들
+    @OneToMany(mappedBy = "fromWayPoint", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Route> routesFrom = new ArrayList<>();
+
+    // toWayPoint로 연결된 Route들
+    @OneToMany(mappedBy = "toWayPoint", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Route> routesTo = new ArrayList<>();
 
 
     public Waypoint(String name, String description, String address, LocalDateTime startTime, LocalDateTime endTime, LocationCategory locationCategory, LocationSubCategory locationSubCategory,Float xPosition, Float yPosition) {


### PR DESCRIPTION
## 관련된 ISSUE 
- related:  #67 

## 요약
- [x] 기능 추가 : Plan ↔ Waypoint ↔ Route ↔ Memo 
ascade = CascadeType.ALL, orphanRemoval = true 적용
- [x] 기능 추가 : Waypoint ↔ Route 
ascade = CascadeType.ALL, orphanRemoval = true 적용


## 얻어낸 효과 
    연관관계때문에 삭제가 안되던 plan 삭제가능
plan 삭제시 관련된 waypoint route memo 삭제
waypoint삭제시 관련된 route 삭제

## 설명
멘토님의 피드백을 보고 cascase 옵션을 사용해도 괜찮겠다고 생각해 cascasde 옵션을 사용했습니다.
원래 단방향이었던 plan과 컴포넌트들을 양방향으로 설정했습니다.

