### PR TITLE
feat(cors): .allowedOrigins 메서드를 한 번만 호출하도록 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebMvcConfig.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/global/config/WebMvcConfig.java
@@ -22,9 +22,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://journey-planner-deployment.vercel.app/")
-                .allowedOrigins("http://localhost:5173")
-                .allowedOrigins("http://121.182.116.155:5137")
+                .allowedOrigins("https://journey-planner-deployment.vercel.app/", "http://localhost:5173", "http://121.182.116.155:5137")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
# [develop ← feat/cors] CORS 해결 : allowedOrigins를 한 번만 호출하도록 수정

## 요약
- 기능 추가 : 해당 없음
- 버그 수정 
  - bMvcConfigurer의 addCorsMappings 설정에서 .allowedOrigins() 메서드를 여러 번 호출하여 CORS 설정이 마지막 값으로 덮어씌워지던 문제를 수정했습니다.
  - 여러 출처(Origin)를 하나의 .allowedOrigins() 메서드에 인자로 모두 전달하여, 지정된 모든 프론트엔드 주소(localhost, Vercel 배포 주소 등)의 API 요청을 정상적으로 허용하도록 수정했습니다.

- [x] 리팩토링 : CORS 설정을 보다 명확하고 올바른 방식으로 개선했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CORS configuration code organization by consolidating multiple origin declarations into a single statement. No functional changes to cross-origin resource sharing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->