### PR TITLE
🧩 [develop ← feature/api-refactor] route 응답에 더 이상 planId를 반환하지 않도록 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/route/dto/response/RouteResponse.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/route/dto/response/RouteResponse.java
@@ -5,7 +5,6 @@ import com.kakaotechcampus.journey_planner.domain.route.VehicleCategory;
 
 public record RouteResponse(
         Long id,
-        Long planId,
         Long fromWaypointId,
         Long toWaypointId,
         String title,
@@ -16,7 +15,6 @@ public record RouteResponse(
     public static RouteResponse from(Route r) {
         return new RouteResponse(
                 r.getId(),
-                r.getPlan().getId(),
                 r.getFromWayPoint().getId(),
                 r.getToWayPoint().getId(),
                 r.getTitle(),


### PR DESCRIPTION
# 🧩 [develop ← feature/api-refactor] route 응답에 더 이상 planId를 반환하지 않도록 수정

## 관련된 ISSUE
- None

## 요약
- [ ] 리팩토링 : route 응답에 더 이상 planId를 반환하지 않도록 수정

## 얻어낸 효과
- 프론트엔드에서 필요하지 않은 정보를 넘기던 문제를 수정했습니다.

## 궁금한 점
- None

## Reference
- None