### PR TITLE
[develop ← fix/member-patch] 사용자 정보 수정 내역이 DB에 반영되지 않는 현상 해결

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/application/member/MemberService.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/application/member/MemberService.java
@@ -29,10 +29,12 @@ public class MemberService {
                 .toList();
     }
 
+    @Transactional
     public void deleteById(Long memberId) {
         memberRepository.deleteById(memberId);
     }
 
+    @Transactional
     public GetMember200Response modifyMember(Long memberId, ModifyMemberRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
@@ -47,6 +49,7 @@ public class MemberService {
         return GetMember200Response.to(member);
     }
 
+    @Transactional
     public void quitMember(Long memberId, QuitMemberRequest request) throws BusinessException {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));


### PR DESCRIPTION
## 요약
- [ ] 기능 추가 : 
- [x] 버그 수정 : 사용자 정보 수정 내역이 DB에 반영되지 않는 현상 해결
  - modifyMember 메서드에 @Transactional 어노테이션을 추가하여 해결.
  - delete 메서드에도 @Transactional 추가
- [ ] 리팩토링 : 

## 문제 발생 이유

### `@Transactional` 의 작동 원리

1. 트랜잭션 시작: `@Transactional`이 붙어있으면, modifyMember 메서드가 시작될 때 스프링이 데이터베이스 트랜잭션을 시작함.

2. 엔티티 조회 (영속성 컨텍스트): memberRepository.findById(memberId)가 호출되면, JPA는 DB에서 Member 객체를 가져와 **영속성 컨텍스트**라는 특별한 관리 공간에 넣음.

3. 변경 발생: member.modify(request)가 호출되면, 영속성 컨텍스트가 관리하던 Member 객체의 내부 값이 변경됨. JPA는 이 객체가 "더러워졌다(Dirty)"고 인지.

4. 메서드 종료 (트랜잭션 커밋)
- 메서드가 정상적으로 끝나면, @Transactional은 트랜잭션을 **"커밋(Commit)"**하려고 함.
- JPA는 커밋 직전에, 영속성 컨텍스트가 관리하는 객체 중 "더러워진(Dirty)" 객체가 있는지 검사함.
- Member 객체가 더러워진 것을 발견하고, JPA가 자동으로 UPDATE SQL 쿼리를 생성해서 DB에 날림.
- 트랜잭션이 커밋되고, 변경 사항이 DB에 영구적으로 반영됨.

### `@Transactional`이 없다면?
1. 트랜잭션 없음: 메서드가 시작해도 트랜잭션이 없음.
2. 조회만: findById로 객체를 조회하지만, 메서드가 끝날 때 커밋할 트랜잭션이 없음.
3. 변경 감지 안 함: "커밋" 시점이 없으므로, JPA가 변경 감지(Dirty Checking)를 수행할 이유도, UPDATE 쿼리를 날릴 이유도 없음.
4. 수정 내역 증발: member.modify(request)로 인한 변경은 오직 메모리 속 Java 객체에만 일어났다가, 메서드가 끝나면 그대로 사라짐.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data consistency and reliability for member management operations by implementing transactional context for delete, modify, and quit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->