### PR TITLE
[develop ←refactor/remove-dto-validation] FE의 요청으로 Memo, Waypoint, Route 요청에 대한 유효성 검증 로직 제거 

### DIFF
--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/memo/dto/request/MemoRequest.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/memo/dto/request/MemoRequest.java
@@ -8,10 +8,8 @@ public record MemoRequest(
 
         String content,
 
-        @NotNull(message = "x좌표는 필수 입력값입니다.")
         Float xPosition,
 
-        @NotNull(message = "y좌표는 필수 입력값입니다.")
         Float yPosition,
 
         Long waypointId,

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/route/dto/request/RouteRequest.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/route/dto/request/RouteRequest.java
@@ -7,23 +7,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record RouteRequest(
-
-        @NotNull(message = "출발 웨이포인트 ID는 필수입니다.")
         Long fromWaypointId,
-
-        @NotNull(message = "도착 웨이포인트 ID는 필수입니다.")
         Long toWaypointId,
-
-        @NotBlank(message = "제목은 필수입니다.")
         String title,
-
         String description,
-
-        @NotNull(message = "duration은 필수입니다.")
-        @Positive(message = "duration은 0보다 커야 합니다.")
         Float duration,
-
-        @NotNull(message = "vehicleCategory는 필수입니다.")
         VehicleCategory vehicleCategory
 ) {
 }

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/waypoint/dto/request/WaypointRequest.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/waypoint/dto/request/WaypointRequest.java
@@ -7,26 +7,20 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record WaypointRequest(
-        @Size(max = 20, message = "웨이포인트명은 최대 20자까지 허용됩니다.")
         String name,
 
         String description,
 
         String address,
 
-        @NotNull
         LocalDateTime startTime,
 
-        @NotNull
         LocalDateTime endTime,
 
-        @NotNull
         LocationCategory locationCategory,
 
-        @NotNull(message = "x좌표는 필수 입력값입니다.")
         Float xPosition,
 
-        @NotNull(message = "y좌표는 필수 입력값입니다.")
         Float yPosition
 ) {
 }


### PR DESCRIPTION
## 요약
- [ ] 기능 추가 : 
- [ ] 버그 수정 :
- [x] 리팩토링 : Request Dto의 유효성 검증 어노테이션을 삭제함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation requirements for position coordinates and temporal/location configuration fields, allowing the application to process a broader range of input combinations in planning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->