### PR TITLE
[develop ← chore/db-schema-update] DB 스키마 업데이트를 위해 jpa.hibernate.ddl-auto를 create로 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     name: JourneyPlanner
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified database schema management configuration. The application now recreates the complete database schema on startup instead of applying incremental updates, ensuring consistent schema state across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->