### PR TITLE
[develop ← chore/db-schema-update] 변경된 DB 스키마 아래, 재 배포시 데이터가 유지되도록 jpa.hibernate.ddl-auto를 update로 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     name: JourneyPlanner
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database initialization behavior to preserve existing data during application restarts instead of recreating the schema from scratch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->