### PR TITLE
[develop ← Feat/get-travelers] 사용자 본인의 member_id 를 반환하는 API 작성, 헬스 체크 엔드포인트 활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// * Spring Boot Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 ext {

--- a/src/main/java/com/kakaotechcampus/journey_planner/presentation/member/MemberController.java
+++ b/src/main/java/com/kakaotechcampus/journey_planner/presentation/member/MemberController.java
@@ -40,6 +40,11 @@ public class MemberController {
         return ResponseEntity.ok().body(memberService.getMemberById(memberId));
     }
 
+    @GetMapping("/me/id")
+    public ResponseEntity<Long> getMyId(@LoginMember Long memberId) {
+        return ResponseEntity.ok(memberId);
+    }
+
     @PatchMapping("/me")
     public ResponseEntity<GetMember200Response> updateMemberInformation(
             @LoginMember Long memberId,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,3 +37,12 @@ springdoc:
     tags-sorter: alpha
     tryItOutEnabled: true
   default-produces-media-type: application/json
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## 요약
- [x] 기능 추가
  1. JWT 토큰을 이용해 사용자 본인의 memberId를 반환하는 API 작성
  2. spring-boot-starter-actuator 라이브러리를 추가하여 헬스 체크 엔드포인트 활성화 
- [ ] 버그 수정 :
- [ ] 리팩토링 : 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint for authenticated users to retrieve their member ID
  * Enabled health monitoring and diagnostic details through management endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->